### PR TITLE
Add in optional priority to surface rules, fixes #51

### DIFF
--- a/common/src/main/java/dev/worldgen/lithostitched/worldgen/modifier/AddSurfaceRuleModifier.java
+++ b/common/src/main/java/dev/worldgen/lithostitched/worldgen/modifier/AddSurfaceRuleModifier.java
@@ -1,5 +1,6 @@
 package dev.worldgen.lithostitched.worldgen.modifier;
 
+import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.registries.Registries;
@@ -15,10 +16,11 @@ import java.util.List;
  *
  * @author Apollo
  */
-public record AddSurfaceRuleModifier(List<ResourceKey<LevelStem>> levels, SurfaceRules.RuleSource surfaceRule) implements Modifier {
+public record AddSurfaceRuleModifier(List<ResourceKey<LevelStem>> levels, SurfaceRules.RuleSource surfaceRule, int priority) implements Modifier {
     public static final MapCodec<AddSurfaceRuleModifier> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
         ResourceKey.codec(Registries.LEVEL_STEM).listOf().fieldOf("levels").forGetter(AddSurfaceRuleModifier::levels),
-        SurfaceRules.RuleSource.CODEC.fieldOf("surface_rule").forGetter(AddSurfaceRuleModifier::surfaceRule)
+        SurfaceRules.RuleSource.CODEC.fieldOf("surface_rule").forGetter(AddSurfaceRuleModifier::surfaceRule),
+        Codec.INT.fieldOf("priority").orElse(0).forGetter(AddSurfaceRuleModifier::priority)
     ).apply(instance, AddSurfaceRuleModifier::new));
 
     @Override

--- a/common/src/main/java/dev/worldgen/lithostitched/worldgen/surface/SurfaceRuleManager.java
+++ b/common/src/main/java/dev/worldgen/lithostitched/worldgen/surface/SurfaceRuleManager.java
@@ -78,7 +78,9 @@ public class SurfaceRuleManager {
     private static SurfaceRules.RuleSource buildModdedSurfaceRules(ArrayList<Pair<ResourceLocation, AddSurfaceRuleModifier>> moddedSourceList, SurfaceRules.RuleSource originalSource) {
         // TODO: Implement caching
         List<SurfaceRules.RuleSource> newRuleSourceList = new ArrayList<>();
+        moddedSourceList.sort((loc, pair) -> pair.getSecond().priority());
         moddedSourceList.forEach((pair) -> newRuleSourceList.add(pair.getSecond().surfaceRule()));
+
 
         newRuleSourceList.add(originalSource);
         if (originalSource instanceof LithostitchedSurfaceRules.TransientMergedRuleSource) {

--- a/common/src/main/java/dev/worldgen/lithostitched/worldgen/surface/SurfaceRuleManager.java
+++ b/common/src/main/java/dev/worldgen/lithostitched/worldgen/surface/SurfaceRuleManager.java
@@ -17,10 +17,7 @@ import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
 import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.SurfaceRules;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -78,9 +75,9 @@ public class SurfaceRuleManager {
     private static SurfaceRules.RuleSource buildModdedSurfaceRules(ArrayList<Pair<ResourceLocation, AddSurfaceRuleModifier>> moddedSourceList, SurfaceRules.RuleSource originalSource) {
         // TODO: Implement caching
         List<SurfaceRules.RuleSource> newRuleSourceList = new ArrayList<>();
-        moddedSourceList.sort((loc, pair) -> pair.getSecond().priority());
+        Comparator<Pair<ResourceLocation, AddSurfaceRuleModifier>> comp = Comparator.comparingInt(pair -> pair.getSecond().priority());
+        moddedSourceList.sort(comp.reversed());
         moddedSourceList.forEach((pair) -> newRuleSourceList.add(pair.getSecond().surfaceRule()));
-
 
         newRuleSourceList.add(originalSource);
         if (originalSource instanceof LithostitchedSurfaceRules.TransientMergedRuleSource) {


### PR DESCRIPTION
Intended for use with mods/datapacks like my [_Natural Philosophy_](https://modrinth.com/mod/natural-philosophy) biome overhaul, where I wanted to factor out my `cliffs` surface rule into a separate file, rather than need to have a file to apply it to "generic biomes" and then include either do-not-fill `not` conditions or alternate cliff conditions in biome files.