### PR TITLE
feat: mod_loaded placement condition

### DIFF
--- a/common/src/main/java/dev/worldgen/lithostitched/LithostitchedCommon.java
+++ b/common/src/main/java/dev/worldgen/lithostitched/LithostitchedCommon.java
@@ -141,6 +141,7 @@ public final class LithostitchedCommon {
 		consumer.accept("sample_density", SampleDensityPlacementCondition.CODEC);
 		consumer.accept("sample_noise_router", SampleNoiseRouterPlacementCondition.CODEC);
 		consumer.accept("true", TruePlacementCondition.CODEC);
+        consumer.accept("mod_loaded", ModLoadedPlacementCondition.CODEC);
 	}
 
 	public static void registerCommonStructureProcessors(BiConsumer<String, StructureProcessorType<?>> consumer) {

--- a/common/src/main/java/dev/worldgen/lithostitched/worldgen/placementcondition/ModLoadedPlacementCondition.java
+++ b/common/src/main/java/dev/worldgen/lithostitched/worldgen/placementcondition/ModLoadedPlacementCondition.java
@@ -1,0 +1,23 @@
+package dev.worldgen.lithostitched.worldgen.placementcondition;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.worldgen.lithostitched.platform.Services;
+import net.minecraft.core.BlockPos;
+
+public record ModLoadedPlacementCondition(String mod) implements PlacementCondition {
+    public static final MapCodec<ModLoadedPlacementCondition> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            Codec.string(2, 64).fieldOf("mod").forGetter(ModLoadedPlacementCondition::mod)
+    ).apply(instance, ModLoadedPlacementCondition::new));
+
+    @Override
+    public boolean test(Context context, BlockPos pos) {
+        return Services.PLATFORM.isModLoaded(mod);
+    }
+
+    @Override
+    public MapCodec<? extends PlacementCondition> codec() {
+        return CODEC;
+    }
+}


### PR DESCRIPTION
Uses platform implementation to add a placement condition that checks if specified mod is loaded
Can be used for various mod integration in mods and datapacks that use lithostitched
Format:
```json
  "spawn_condition": {
    "type": "lithostitched:mod_loaded",
    "mod": "waystones"
  }
```

Tested on fabric and neoforge 1.21.6

