### PR TITLE
Update TransientMergedRule for lower performance impact

### DIFF
--- a/src/common/main/java/dev/worldgen/lithostitched/worldgen/surface/rule/TransientMergedRule.java
+++ b/src/common/main/java/dev/worldgen/lithostitched/worldgen/surface/rule/TransientMergedRule.java
@@ -34,9 +34,9 @@ public record TransientMergedRule(List<SurfaceRules.RuleSource> sequence, Surfac
             for (SurfaceRules.RuleSource ruleSource : this.sequence) {
                 builder.add(ruleSource.apply(context));
             }
-            builder.add(this.original.apply(context));
+            ImmutableList<SurfaceRules.SurfaceRule> list = builder.add(this.original.apply(context)).build();
             return (x, y, z) -> {
-                for (SurfaceRules.SurfaceRule surfaceRule : builder.build()) {
+                for (SurfaceRules.SurfaceRule surfaceRule : list) {
                     BlockState blockstate = surfaceRule.tryApply(x, y, z);
                     if (blockstate != null) {
                         return blockstate;


### PR DESCRIPTION
By moving the call to `builder.build()` out of the lambda, we remove it being run for every block - instead, it's run once per chunk, when surface rules are collected.

This removes a noticeable overall system performance impact from Spark profiling, as can be seen [here](https://spark.lucko.me/ISYpAaXeXi). Note that under `TransientMergedSurfaceRule`, the call to `ImmutableList$Builder.build()` takes up roughly 9% of total `TransientMergedSurfaceRule.apply()` time.