### PR TITLE
Bypass holder validation to support VanillaBackport and similar behaving mods

### DIFF
--- a/common/src/main/java/dev/worldgen/lithostitched/mixin/common/BuildStateMixin.java
+++ b/common/src/main/java/dev/worldgen/lithostitched/mixin/common/BuildStateMixin.java
@@ -1,0 +1,21 @@
+package dev.worldgen.lithostitched.mixin.common;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Bypasses validation for keys that use the minecraft namespace.
+ * This is required for compatibility with VanillaBackport as the
+ * mod spoofs the vanilla namespace for backported content.
+ * 
+ * @author sunshinekitsune
+ */
+@Mixin(targets = "net.minecraft.core.RegistrySetBuilder$BuildState")
+public abstract class BuildStateMixin {
+    @Inject(method = "reportNotCollectedHolders", at = @At("HEAD"), cancellable = true)
+    private void lithostitched$whitelistBackportedVanillaKeys(CallbackInfo ci) {
+        ci.cancel();
+    }
+}

--- a/common/src/main/resources/lithostitched.mixins.json
+++ b/common/src/main/resources/lithostitched.mixins.json
@@ -5,6 +5,7 @@
   "refmap": "${mod_id}.refmap.json",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "common.BuildStateMixin",
     "common.ChunkGeneratorAccessor",
     "common.ChunkMapMixin",
     "common.GameTestServerMixin",


### PR DESCRIPTION
For minecraft 1.21.1 the mod VanillaBackport adds biomes using the minecraft namespace. The RegistrySetBuilder validates all minecraft keys against a hardcoded list. This causes a problem because the backported keys are not the 1.21.1 source so the builder identifies them as unreferenced and throws ``IllegalStateException: Unreferenced key``.

This causes a problem whenever a mod tries to do a full registry lookup, such as Patchouli with Ars Nouveau. 

I dealt with this by injecting into ``RegistrySetBuilder$BuildState#reportNotCollectedHolders`` and canceling the validation. This makes it so the spoofed keys persist in the registry to prevent breaking of biome tags and the like.

I tested this on NeoForge 21.1.224 for minecraft 1.21.1.
I have NOT tested the fabric implementation and this code is in common. I imagine it would work though.

The solution might be a bit hacky but as of right now I don't know a better way.