### PR TITLE
Fix: wrap_noise_router modifiers applying to every dimension

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 group = "dev.worldgen.lithostitched"
-version = "1.7.11"
+version = "1.7.12"
 
 cloche {
     metadata {

--- a/src/common/main/java/dev/worldgen/lithostitched/mixin/common/ChunkMapMixin.java
+++ b/src/common/main/java/dev/worldgen/lithostitched/mixin/common/ChunkMapMixin.java
@@ -9,8 +9,10 @@ import dev.worldgen.lithostitched.impl.worldgen.modifier.ModifierManager;
 import dev.worldgen.lithostitched.worldgen.modifier.WrapNoiseRouterModifier;
 import net.minecraft.core.HolderGetter;
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.NoiseRouter;
 import net.minecraft.world.level.levelgen.RandomState;
@@ -36,7 +38,18 @@ public class ChunkMapMixin {
         NoiseGeneratorSettingsAccessor accessor = ((NoiseGeneratorSettingsAccessor)(Object)noiseSettings);
         NoiseRouter router = noiseSettings.noiseRouter();
 
-        List<WrapNoiseRouterModifier> modifiers = ModifierManager.getModifiersOfType(registries, WrapNoiseRouterModifier.CODEC).stream().map(Map.Entry::getValue).toList();
+        ResourceKey<Level> dimension = level.dimension();
+        List<WrapNoiseRouterModifier> modifiers = ModifierManager.getModifiersOfType(registries, WrapNoiseRouterModifier.CODEC).stream()
+            .filter(entry -> {
+                ResourceKey<Level> declared = entry.getValue().dimension();
+                if (declared == null) {
+                    Lithostitched.LOGGER.warn("Wrap noise router modifier {} has no dimension; applying to all dimensions", entry.getKey());
+                    return true;
+                }
+                return declared.equals(dimension);
+            })
+            .map(Map.Entry::getValue)
+            .toList();
 
         if (!modifiers.isEmpty()) {
             accessor.setNoiseRouter(new NoiseRouter(

--- a/uploader.py
+++ b/uploader.py
@@ -5,8 +5,14 @@ import json
 # Per-mod: Update this for each mod!!!
 
 MOD_ID = "lithostitched"
-MOD_VERSION = "1.7.11"
+MOD_VERSION = "1.7.12"
 CHANGELOG = """
+## 1.7.12
+
+**Fixes**
+
+- Fixed `wrap_noise_router` modifiers applying to every dimension instead of only their declared `dimension`.
+
 ## 1.7.11
 
 - Made code changes to prepare for full World Preview compatibility.


### PR DESCRIPTION
## Symptom

`wrap_noise_router` modifiers leak across dimensions. A modifier that declares `"dimension": "minecraft:overworld"` and replaces the overworld's `final_density` also gets applied to the nether and end, overwriting their terrain with the overworld formula (built around `minecraft:overworld/sloped_cheese`). Any mod or datapack using `wrap_noise_router` to alter overworld cave/terrain generation corrupts nether and end generation as a side effect.

This can't be worked around in user data on 26.2: the cheese-cave noises are inlined into the overworld's `final_density` rather than exposed as named density functions, so `wrap_density_function` can't surgically remove them. The full router-entry swap is the only mechanism, which is exactly why the dimension gate has to be enforced here.

## Root cause

The `dimension` field is parsed but never actually used:

1. `WrapNoiseRouterModifier`'s codec parses the **required** `dimension` field into the record (`WrapNoiseRouterModifier.java:25`), but nothing ever reads that value
2. The modifiers are applied in `ChunkMapMixin.wrapNoiseRouter`, which wraps `RandomState.create` in the `ChunkMap` constructor and fires once per `ServerLevel` as each dimension's chunk map is built.
3. The modifier list at that site is fetched globally and filtered **only by `target`** (inside `WrapNoiseRouterModifier.modifyDensityFunction`). The `ServerLevel` (and dimension key, by extension) are never consulted, so every `wrap_noise_router` modifier is applied to every dimension's noise router.

## Fix

Two candidate shapes were considered:

- **(a) Gate at the application site:** when applying `wrap_noise_router` modifiers in `ChunkMapMixin`, skip any whose declared dimension doesn't match the current `ServerLevel`'s dimension key.
- **(b) Generalize:** give noise-router modifiers an optional dimension predicate that the application loop consults, so scoping isn't a `WrapNoiseRouter` special case.

**Picked (a).** `WrapNoiseRouterModifier` is the *only* modifier type on this application path. `wrap_density_function` mutates named registry density functions in `apply()` and is intentionally global (no dimension concept), and the surface-rule / biome-injector subsystems already scope by dimension correctly (`SurfaceRuleManager`, `BiomeInjectorManager`). A generalized predicate interface would be an abstraction with a single implementor; if more router-modifier types appear later, this filter generalizes naturally.

**Where the gate sits:** `ChunkMapMixin.wrapNoiseRouter` (`src/common`, shared by both loaders and all supported MC versions). The `ServerLevel` is already a captured parameter of the mixin method, so `level.dimension()` provides the `ResourceKey<Level>` directly. The modifier list is now filtered by `declared.equals(level.dimension())` before the router is rebuilt; when no modifiers match the current dimension, the existing `modifiers.isEmpty()` short-circuit leaves that dimension's router completely untouched.

## Compatibility impact

- The `dimension` field has been **required** since 1.3.1a, so every existing `wrap_noise_router` modifier in the wild already declares one, and the declared intent was always single-dimension. Matching is exact.
- The only behavior change is that modifiers no longer apply to dimensions they never declared. A modifier matching the current dimension applies exactly as before (same priority-sorted wrap order).
- **Null/absent dimension:** impossible from data (the codec rejects it). It can only arise from direct Java construction; in that case the modifier applies everywhere (the old behavior) and a warning naming the modifier id is logged.
- Known pre-existing limitation (out of scope): the router swap mutates the shared `NoiseGeneratorSettings` registry object, so two dimensions referencing the *same* noise-settings entry still share one wrapped router.

## Verification

No test harness exists in this repo, so this was verified with the real affected mod: **[Schworlium v0.1+mc26.2](https://github.com/ndellagrotte/schworlium/releases/tag/v0.1%2Bmc26.2)**, which ships `data/schworlium/lithostitched/worldgen_modifier/disable_noise_caves.json` — a `lithostitched:wrap_noise_router` with `"dimension": "minecraft:overworld"`, `"target": "final_density"`, whose wrapper rebuilds overworld terrain around `minecraft:overworld/sloped_cheese` with the noise caves removed. That is exactly the leak scenario.

1. **Before (repro):** MC 26.2 instance with Lithostitched 1.7.11 + Schworlium v0.1+mc26.2, fixed seed. Overworld generates without noise caves (intended); nether and end terrain is replaced by the overworld formula (the bug).
2. **After:** same instance and seed with this patched build. Overworld is still modified as intended; nether and end generate vanilla (compared visually against a Lithostitched-only world at the same seed).
3. `gradlew build` passes for all targets (fabric + neoforge × 21.1 / 26.1 / 26.2) — the fix is a single change in the shared `common` module.

## Follow-up ideas (not in this PR)

- Accept a dimension **list or tag** in `wrap_noise_router` (cheap, natural extension — `add_surface_rule` already takes a list of levels).
- Copy `NoiseGeneratorSettings` instead of mutating the shared registry entry, so dimensions sharing a settings entry can diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)